### PR TITLE
Update the MAINTAINERS instructions regarding secrets in GitHub

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,9 +6,10 @@ This document describes some instructions for maintainers. Other contributors an
 
 When setting up the repository on GitHub, configure the following settings:
 
-- Under `Secrets`, add the following repository secrets with appropriate values:
+- Under `Secrets > Actions`, add the following repository secrets with appropriate values:
   - `CRATES_IO_TOKEN`
   - `DOCKER_PASSWORD`
+- Add the same secrets to `Secrets > Dependabot`.
 - Under `Branches`, add a branch protection rule for the `main` branch.
   - Enable `Require status checks to pass before merging`.
     - Enable `Require branches to be up to date before merging`.


### PR DESCRIPTION
Update the `MAINTAINERS` instructions regarding secrets in GitHub.

**Status:** Ready

**Fixes:** N/A