### PR TITLE
Update the way lints are configured to use Rust's new `manifest-lint` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,10 @@ homepage = "https://github.com/stepchowfun/stem-cell"
 repository = "https://github.com/stepchowfun/stem-cell"
 readme = "README.md"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]
 clap = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 use clap::App;
 
 // The program version


### PR DESCRIPTION
Update the way lints are configured to use Rust's new `manifest-lint` feature

**Status:** Ready

**Fixes:** N/A