### PR TITLE
Enable reading from the remote Toast cache for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         tasks: build test lint release run
         docker_repo: stephanmisc/toast
-        read_remote_cache: ${{ github.event_name == 'push' }}
+        read_remote_cache: true
         write_remote_cache: ${{ github.event_name == 'push' }}
     - run: |
         # Make Bash not silently ignore errors.


### PR DESCRIPTION
Enable reading from the remote Toast cache for pull requests.

**Status:** Ready

**Fixes:** N/A