### PR TITLE
Update Rust to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.94.1 --no-self-update # [ref:rust_1.94.1]
-        rustup default 1.94.1 # [ref:rust_1.94.1]
+        rustup toolchain install 1.95.0 --no-self-update # [ref:rust_1.95.0]
+        rustup default 1.95.0 # [ref:rust_1.95.0]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -124,8 +124,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.94.1 # [ref:rust_1.94.1]
-        rustup default 1.94.1 # [ref:rust_1.94.1]
+        rustup toolchain install 1.95.0 # [ref:rust_1.95.0]
+        rustup default 1.95.0 # [ref:rust_1.95.0]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -204,8 +204,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.94.1 # [ref:rust_1.94.1]
-        rustup default 1.94.1 # [ref:rust_1.94.1]
+        rustup toolchain install 1.95.0 # [ref:rust_1.95.0]
+        rustup default 1.95.0 # [ref:rust_1.95.0]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-04-06]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-04-17]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-04-06 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-04-17 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -69,18 +69,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.94.1].
+      # Install stable Rust [tag:rust_1.95.0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.94.1 \
+        --default-toolchain 1.95.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-04-06].
-      rustup toolchain install nightly-2026-04-06 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-04-17].
+      rustup toolchain install nightly-2026-04-17 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
## Summary
- Update stable Rust pins from 1.94.1 to 1.95.0.
- Update the Toast rustfmt nightly toolchain to nightly-2026-04-17.

## Testing
- rustup toolchain install 1.95.0 --profile minimal --component clippy
- rustup toolchain install nightly-2026-04-17 --profile minimal --component rustfmt
- git diff --check
- tagref
- tagref list-unused --fail-if-any