### PR TITLE
Install the latest release by default

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,7 +30,4 @@ The GitHub workflow will fail initially because the jobs which test the installe
 
 ### Release instructions
 
-Releasing a new version is a two-step process:
-
-1. Bump the version in `[file:Cargo.toml]`, run `cargo build` to update `[file:Cargo.lock]`, and update `[file:CHANGELOG.md]` with information about the new version. Ship those changes as a single commit.
-2. Once the GitHub workflow has finished on the `main` branch, update the version in `[file:install.sh]` to point to the new release.
+To release a new version, bump the version in `[file:Cargo.toml]`, run `cargo build` to update `[file:Cargo.lock]`, and update `[file:CHANGELOG.md]` with information about the new version. Ship those changes as a single commit. Once the GitHub workflow publishes the release, the installation script will begin installing it by default.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a simple project to demonstrate the cross-platform release management pr
 This repository can be used as a starting point for a new project. Follow these instructions:
 
 1. Rename all references to `Stem Cell` and `stem-cell` accordingly.
-2. Reset the version (e.g., to `0.0.0`) in `[file:Cargo.toml]` and `[file:install.sh]`.
+2. Reset the version (e.g., to `0.0.0`) in `[file:Cargo.toml]`.
 3. Run `cargo build` to update the version in `[file:Cargo.lock]`.
 4. Delete the entries in `[file:CHANGELOG.md]` except the one about the initial version.
 5. Follow the instructions in `[file:MAINTAINERS.md]` to configure the repository on GitHub.

--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,6 @@
   # Where the binary will be installed
   DESTINATION="${PREFIX:-/usr/local/bin}/stem-cell"
 
-  # Which version to download
-  RELEASE="v${VERSION:-0.1.0}"
-
   # Determine which binary to download.
   FILENAME=''
   if uname -a | grep -qi 'x86_64.*GNU/Linux'; then
@@ -56,9 +53,16 @@
   # Compute the full file path.
   SOURCE="$TEMPDIR/$FILENAME"
 
+  # Download the requested version, or the latest published version by default.
+  if [ -n "${VERSION:-}" ]; then
+    RELEASE_PATH="download/v$VERSION"
+  else
+    RELEASE_PATH=latest
+  fi
+
   # Download the binary.
   curl \
-    "https://github.com/stepchowfun/stem-cell/releases/download/$RELEASE/$FILENAME" \
+    "https://github.com/stepchowfun/stem-cell/releases/$RELEASE_PATH/download/$FILENAME" \
     -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
 
   # Make it executable.

--- a/install.sh
+++ b/install.sh
@@ -55,15 +55,13 @@
 
   # Download the requested version, or the latest published version by default.
   if [ -n "${VERSION:-}" ]; then
-    RELEASE_PATH="download/v$VERSION"
+    DOWNLOAD_URL="https://github.com/stepchowfun/stem-cell/releases/download/v$VERSION/$FILENAME"
   else
-    RELEASE_PATH=latest
+    DOWNLOAD_URL="https://github.com/stepchowfun/stem-cell/releases/latest/download/$FILENAME"
   fi
 
   # Download the binary.
-  curl \
-    "https://github.com/stepchowfun/stem-cell/releases/$RELEASE_PATH/download/$FILENAME" \
-    -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
+  curl "$DOWNLOAD_URL" -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
 
   # Make it executable.
   chmod a+x "$SOURCE" || fail 'There was an error setting the permissions for the binary.'


### PR DESCRIPTION
Use the latest published GitHub release when `VERSION` is not set, while preserving explicit version selection with `VERSION=x.y.z`. This removes the follow-up installer bump from the release process.

**Status:** Ready

**Fixes:** N/A
