### PR TITLE
Update Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.97.1 --no-self-update # [ref:rust_1.97.1]
-        rustup default 1.97.1 # [ref:rust_1.97.1]
+        rustup toolchain install 1.98.0 --no-self-update # [ref:rust_1.98.0]
+        rustup default 1.98.0 # [ref:rust_1.98.0]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -124,8 +124,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.97.1 # [ref:rust_1.97.1]
-        rustup default 1.97.1 # [ref:rust_1.97.1]
+        rustup toolchain install 1.98.0 # [ref:rust_1.98.0]
+        rustup default 1.98.0 # [ref:rust_1.98.0]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -204,8 +204,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.97.1 # [ref:rust_1.97.1]
-        rustup default 1.97.1 # [ref:rust_1.97.1]
+        rustup toolchain install 1.98.0 # [ref:rust_1.98.0]
+        rustup default 1.98.0 # [ref:rust_1.98.0]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-18]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-08-21]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-07-18 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-08-21 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -69,18 +69,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.97.1].
+      # Install stable Rust [tag:rust_1.98.0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.97.1 \
+        --default-toolchain 1.98.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-18].
-      rustup toolchain install nightly-2026-07-18 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-08-21].
+      rustup toolchain install nightly-2026-08-21 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
Updates Rust from 1.97.1 to 1.98.0 and nightly rustfmt from 2026-07-18 to 2026-08-21. Release notes did not require source changes.

Copyright is already current at 2026 where LICENSE.md is present. No submodule update applies.

**Status:** Ready

**Fixes:** N/A
